### PR TITLE
update pkgrel to match the one in .SRCINFO

### DIFF
--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname=songrec
 _pkgname=SongRec
 pkgver=0.1.8
-pkgrel=1
+pkgrel=2
 provides=('songrec')
 conflicts=('songrec-git')
 pkgdesc='An open-source, unofficial Shazam client for Linux, written in Rust.'


### PR DESCRIPTION
In the .SRCINFO file in the AUR, the pkgrel is 2 (probably due to accident), which causes problems with some AUR helpers; this patch fixes those problems.